### PR TITLE
Add average IO size in storage group metric

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -2864,6 +2864,7 @@ func handleStorageGroupMetrics(w http.ResponseWriter, r *http.Request) {
 		ReadResponseTime:  0.0,
 		WriteResponseTime: 0.0,
 		AllocatedCapacity: 0.0,
+		AvgIOSize:         0.0,
 		Timestamp:         1671091500000,
 	}
 	metricsIterator := &types.StorageGroupMetricsIterator{

--- a/types/v100/performanceMetrics.go
+++ b/types/v100/performanceMetrics.go
@@ -49,6 +49,7 @@ type StorageGroupMetric struct {
 	ReadResponseTime  float64 `json:"ReadResponseTime"`
 	WriteResponseTime float64 `json:"WriteResponseTime"`
 	AllocatedCapacity float64 `json:"AllocatedCapacity"`
+	AvgIOSize         float64 `json:"AvgIOSize"`
 	Timestamp         int64   `json:"timestamp"`
 }
 


### PR DESCRIPTION
# Description
Add a metric for storage group performance query

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/586 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained at least 90% code coverage?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
UT is covered:
![image](https://user-images.githubusercontent.com/105041254/212843946-ca57a419-1f9d-4ee8-a23f-1b85c9e44ecb.png)