### PR TITLE
Feature 770 Storage Group Snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TEST_PATHS=unittest
 debug_port=55555
 
 # These lists contain applicable files 
-srcfiles=		authenticate.go interface.go system.go sloprovisioning.go VolumeSnapshot.go VolumeReplication.go metrics.go ArrayMigration.go
+srcfiles=		authenticate.go interface.go replication.go system.go sloprovisioning.go VolumeSnapshot.go VolumeReplication.go metrics.go ArrayMigration.go
 integrationfiles=	inttest/pmax_integration_test.go inttest/pmax_replication_integration_test.go
 unitfiles=		unit_test.go unit_steps_test.go
 

--- a/interface.go
+++ b/interface.go
@@ -133,6 +133,24 @@ type Pmax interface {
 	// This is done synchronously and no jobs are created. HTTP header argument is optional
 	CreateVolumeInProtectedStorageGroupS(ctx context.Context, symID, remoteSymID, storageGroupID string, remoteStorageGroupID string, volumeName string, volumeSize interface{}, volOpts map[string]interface{}, opts ...http.Header) (*types.Volume, error)
 
+	// Get All Storage Group Snapshots
+	GetStorageGroupSnapshots(ctx context.Context, symID string, storageGroupID string, exludeManualSnaps bool, exludeSlSnaps bool) (*types.StorageGroupSnapshot, error)
+
+	// Get a list of Snapids for a particular snapshot
+	GetStorageGroupSnapshotSnapIds(ctx context.Context, symID string, storageGroupID string, snapshotID string) (*types.SnapID, error)
+
+	// Get the details of a storage group snapshot snap
+	GetStorageGroupSnapshotSnap(ctx context.Context, symID string, storageGroupID string, snapshotID, snapID string) (*types.StorageGroupSnap, error)
+
+	// Create a Storage Group Snapshot
+	CreateStorageGroupSnapshot(ctx context.Context, symID string, storageGroupID string, payload *types.CreateStorageGroupSnapshot) (*types.StorageGroupSnap, error)
+
+	//  Modify a Storage Group Snapshot snap
+	ModifyStorageGroupSnapshot(ctx context.Context, symID string, storageGroupID string, snapshotID string, snapID string, payload *types.ModifyStorageGroupSnapshot) (*types.StorageGroupSnap, error)
+
+	// Delete a Storage Group Snapshot snap
+	DeleteStorageGroupSnapshot(ctx context.Context, symID string, storageGroupID string, snapshotID string, snapID string) error
+
 	// DeleteStorageGroup deletes a storage group given a storage group id
 	DeleteStorageGroup(ctx context.Context, symID string, storageGroupID string) error
 

--- a/inttest/pmax_integration_test.go
+++ b/inttest/pmax_integration_test.go
@@ -65,6 +65,7 @@ var (
 	csiPrefix               = "csi"
 	// the test run will create these for the run and clean up in the end
 	defaultStorageGroup          = "csi-Integration-Test"
+	defaultSnapshotName          = "integration-test-snapshot"
 	defaultProtectedStorageGroup = "csi-Integration-Test-Protected-SG"
 	nonFASTManagedSG             = "csi-Integration-No-FAST"
 	defaultSGWithSnapshotPolicy  = "csi-Integration-Test-With-Snapshot-Policy"

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -114,100 +114,104 @@ var Data struct {
 
 // InducedErrors constants
 var InducedErrors struct {
-	NoConnection                       bool
-	InvalidJSON                        bool
-	BadHTTPStatus                      int
-	GetSymmetrixError                  bool
-	GetVolumeIteratorError             bool
-	GetVolumeError                     bool
-	UpdateVolumeError                  bool
-	DeleteVolumeError                  bool
-	DeviceInSGError                    bool
-	GetStorageGroupError               bool
-	GetStorageGroupSnapshotPolicyError bool
-	InvalidResponse                    bool
-	GetStoragePoolError                bool
-	UpdateStorageGroupError            bool
-	GetJobError                        bool
-	JobFailedError                     bool
-	VolumeNotCreatedError              bool
-	GetJobCannotFindRoleForUser        bool
-	CreateStorageGroupError            bool
-	StorageGroupAlreadyExists          bool
-	DeleteStorageGroupError            bool
-	GetStoragePoolListError            bool
-	GetPortGroupError                  bool
-	GetPortError                       bool
-	GetSpecificPortError               bool
-	GetPortISCSITargetError            bool
-	GetPortGigEError                   bool
-	GetDirectorError                   bool
-	GetInitiatorError                  bool
-	GetInitiatorByIDError              bool
-	GetHostError                       bool
-	CreateHostError                    bool
-	DeleteHostError                    bool
-	UpdateHostError                    bool
-	GetMaskingViewError                bool
-	CreateMaskingViewError             bool
-	UpdateMaskingViewError             bool
-	MaskingViewAlreadyExists           bool
-	DeleteMaskingViewError             bool
-	PortGroupNotFoundError             bool
-	InitiatorGroupNotFoundError        bool
-	StorageGroupNotFoundError          bool
-	VolumeNotAddedError                bool
-	GetMaskingViewConnectionsError     bool
-	ResetAfterFirstError               bool
-	CreateSnapshotError                bool
-	DeleteSnapshotError                bool
-	LinkSnapshotError                  bool
-	RenameSnapshotError                bool
-	GetSymVolumeError                  bool
-	GetVolSnapsError                   bool
-	GetGenerationError                 bool
-	GetPrivateVolumeIterator           bool
-	SnapshotNotLicensed                bool
-	UnisphereMismatchError             bool
-	TargetNotDefinedError              bool
-	SnapshotExpired                    bool
-	InvalidSnapshotName                bool
-	GetPrivVolumeByIDError             bool
-	CreatePortGroupError               bool
-	UpdatePortGroupError               bool
-	DeletePortGroupError               bool
-	ExpandVolumeError                  bool
-	MaxSnapSessionError                bool
-	GetSRDFInfoError                   bool
-	VolumeRdfTypesError                bool
-	GetSRDFPairInfoError               bool
-	GetProtectedStorageGroupError      bool
-	CreateSGReplicaError               bool
-	GetRDFGroupError                   bool
-	GetSGOnRemote                      bool
-	GetSGWithVolOnRemote               bool
-	RDFGroupHasPairError               bool
-	GetRemoteVolumeError               bool
-	InvalidLocalVolumeError            bool
-	InvalidRemoteVolumeError           bool
-	FetchResponseError                 bool
-	RemoveVolumesFromSG                bool
-	ModifyMobilityError                bool
-	GetHostGroupError                  bool
-	CreateHostGroupError               bool
-	DeleteHostGroupError               bool
-	UpdateHostGroupError               bool
-	GetHostGroupListError              bool
-	GetStorageGroupMetricsError        bool
-	GetVolumesMetricsError             bool
-	GetStorageGroupPerfKeyError        bool
-	GetArrayPerfKeyError               bool
-	GetFreeRDFGError                   bool
-	GetLocalOnlineRDFDirsError         bool
-	GetRemoteRDFPortOnSANError         bool
-	GetLocalOnlineRDFPortsError        bool
-	GetLocalRDFPortDetailsError        bool
-	CreateRDFGroupError                bool
+	NoConnection                           bool
+	InvalidJSON                            bool
+	BadHTTPStatus                          int
+	GetSymmetrixError                      bool
+	GetVolumeIteratorError                 bool
+	GetVolumeError                         bool
+	UpdateVolumeError                      bool
+	DeleteVolumeError                      bool
+	DeviceInSGError                        bool
+	GetStorageGroupError                   bool
+	GetStorageGroupSnapshotPolicyError     bool
+	InvalidResponse                        bool
+	GetStoragePoolError                    bool
+	UpdateStorageGroupError                bool
+	GetJobError                            bool
+	JobFailedError                         bool
+	VolumeNotCreatedError                  bool
+	GetJobCannotFindRoleForUser            bool
+	CreateStorageGroupError                bool
+	StorageGroupAlreadyExists              bool
+	DeleteStorageGroupError                bool
+	GetStoragePoolListError                bool
+	GetPortGroupError                      bool
+	GetPortError                           bool
+	GetSpecificPortError                   bool
+	GetPortISCSITargetError                bool
+	GetPortGigEError                       bool
+	GetDirectorError                       bool
+	GetInitiatorError                      bool
+	GetInitiatorByIDError                  bool
+	GetHostError                           bool
+	CreateHostError                        bool
+	DeleteHostError                        bool
+	UpdateHostError                        bool
+	GetMaskingViewError                    bool
+	CreateMaskingViewError                 bool
+	UpdateMaskingViewError                 bool
+	MaskingViewAlreadyExists               bool
+	DeleteMaskingViewError                 bool
+	PortGroupNotFoundError                 bool
+	InitiatorGroupNotFoundError            bool
+	StorageGroupNotFoundError              bool
+	VolumeNotAddedError                    bool
+	GetMaskingViewConnectionsError         bool
+	ResetAfterFirstError                   bool
+	CreateSnapshotError                    bool
+	DeleteSnapshotError                    bool
+	LinkSnapshotError                      bool
+	RenameSnapshotError                    bool
+	GetSymVolumeError                      bool
+	GetVolSnapsError                       bool
+	GetGenerationError                     bool
+	GetPrivateVolumeIterator               bool
+	SnapshotNotLicensed                    bool
+	UnisphereMismatchError                 bool
+	TargetNotDefinedError                  bool
+	SnapshotExpired                        bool
+	InvalidSnapshotName                    bool
+	GetPrivVolumeByIDError                 bool
+	CreatePortGroupError                   bool
+	UpdatePortGroupError                   bool
+	DeletePortGroupError                   bool
+	ExpandVolumeError                      bool
+	MaxSnapSessionError                    bool
+	GetSRDFInfoError                       bool
+	VolumeRdfTypesError                    bool
+	GetSRDFPairInfoError                   bool
+	GetProtectedStorageGroupError          bool
+	CreateSGReplicaError                   bool
+	GetRDFGroupError                       bool
+	GetSGOnRemote                          bool
+	GetSGWithVolOnRemote                   bool
+	RDFGroupHasPairError                   bool
+	GetRemoteVolumeError                   bool
+	InvalidLocalVolumeError                bool
+	InvalidRemoteVolumeError               bool
+	FetchResponseError                     bool
+	RemoveVolumesFromSG                    bool
+	ModifyMobilityError                    bool
+	GetHostGroupError                      bool
+	CreateHostGroupError                   bool
+	DeleteHostGroupError                   bool
+	UpdateHostGroupError                   bool
+	GetHostGroupListError                  bool
+	GetStorageGroupMetricsError            bool
+	GetVolumesMetricsError                 bool
+	GetStorageGroupPerfKeyError            bool
+	GetArrayPerfKeyError                   bool
+	GetFreeRDFGError                       bool
+	GetLocalOnlineRDFDirsError             bool
+	GetRemoteRDFPortOnSANError             bool
+	GetLocalOnlineRDFPortsError            bool
+	GetLocalRDFPortDetailsError            bool
+	CreateRDFGroupError                    bool
+	GetStorageGroupSnapshotError           bool
+	GetStorageGroupSnapshotSnapError       bool
+	GetStorageGroupSnapshotSnapDetailError bool
+	GetStorageGroupSnapshotSnapModifyError bool
 }
 
 // hasError checks to see if the specified error (via pointer)
@@ -321,6 +325,7 @@ func Reset() {
 	InducedErrors.GetLocalOnlineRDFPortsError = false
 	InducedErrors.GetLocalRDFPortDetailsError = false
 	InducedErrors.CreateRDFGroupError = false
+	InducedErrors.GetStorageGroupSnapshotSnapDetailError = false
 	Data.JSONDir = "mock"
 	Data.VolumeIDToIdentifier = make(map[string]string)
 	Data.VolumeIDToSize = make(map[string]int)
@@ -487,6 +492,11 @@ func getRouter() http.Handler {
 	router.HandleFunc(PREFIXNOVERSION+"/version", handleVersion)
 	router.HandleFunc("/", handleNotFound)
 
+	//StorageGroup Snapshots
+	router.HandleFunc(PREFIX+"/replication/symmetrix/{symid}/storagegroup/{StorageGroupId}/snapshot", handleGetStorageGroupSnapshots)
+	router.HandleFunc(PREFIX+"/replication/symmetrix/{symid}/storagegroup/{StorageGroupId}/snapshot/{snapshotId}/snapid", handleGetStorageGroupSnapshotsSnapsIds)
+	router.HandleFunc(PREFIX+"/replication/symmetrix/{symid}/storagegroup/{StorageGroupId}/snapshot/{snapshotId}/snapid/{snapID}", handleGetStorageGroupSnapshotsSnapsDetails)
+
 	//Snapshot
 	router.HandleFunc(PRIVATEPREFIX+"/replication/symmetrix/{symid}/snapshot/{SnapID}", handleSnapshot)
 	router.HandleFunc(PRIVATEPREFIX+"/replication/symmetrix/{symid}/volume", handleSymVolumes)
@@ -520,6 +530,102 @@ func getRouter() http.Handler {
 
 	mockRouter = router
 	return router
+}
+
+// GET /replication/symmetrix/{symid}/storagegroup/{StorageGroupId}/snapshot/{snapshotId}/snapid/{snapID}
+// PUT /replication/symmetrix/{symid}/storagegroup/{StorageGroupId}/snapshot/{snapshotId}/snapid/{snapID}
+// DELETE /replication/symmetrix/{symid}/storagegroup/{StorageGroupId}/snapshot/{snapshotId}/snapid/{snapID}
+func handleGetStorageGroupSnapshotsSnapsDetails(w http.ResponseWriter, r *http.Request) {
+	fmt.Printf("HANDLING GET STORAGE GROUPS SNAPs Details!!!! \n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n")
+	if r.Method != http.MethodGet && r.Method != http.MethodPut && r.Method != http.MethodDelete {
+		writeError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if InducedErrors.GetStorageGroupSnapshotSnapDetailError {
+		writeError(w, "Could not get StorageGroup Snapshots Snap Ids: induced error", http.StatusBadRequest)
+		return
+	}
+	if InducedErrors.GetStorageGroupSnapshotSnapModifyError {
+		writeError(w, "Could not get StorageGroup Snapshots Snap Ids: induced error", http.StatusBadRequest)
+		return
+	}
+	if r.Method == http.MethodGet {
+		sgCreateSnap := &types.StorageGroupSnap{
+			Name:       "sg_1_snap",
+			Generation: 1,
+			SnapID:     2,
+			Timestamp:  "1234",
+		}
+		writeJSON(w, sgCreateSnap)
+		return
+	}
+	if r.Method == http.MethodPut {
+		sgCreateSnap := &types.StorageGroupSnap{
+			Name:       "sg_1_snap_2",
+			Generation: 1,
+			SnapID:     2,
+			Timestamp:  "1234",
+		}
+		writeJSON(w, sgCreateSnap)
+		return
+	}
+
+}
+
+// GET /replication/symmetrix/{symid}/storagegroup/{StorageGroupId}/snapshot/{snapshotId}/snapid
+func handleGetStorageGroupSnapshotsSnapsIds(w http.ResponseWriter, r *http.Request) {
+
+	if r.Method != http.MethodGet {
+		writeError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if InducedErrors.GetStorageGroupSnapshotSnapError {
+		writeError(w, "Could not get StorageGroup Snapshots Snap Ids: induced error", http.StatusBadRequest)
+		return
+	}
+	snaps := make([]int64, 1)
+	snaps = append(snaps, 1234)
+	snapIDs := &types.SnapID{
+		SnapIds: snaps,
+	}
+	writeJSON(w, snapIDs)
+}
+
+// GET /replication/symmetrix/{symid}/storagegroup/{SnapID}/snapshot
+// POST /replication/symmetrix/{symid}/storagegroup/{SnapID}/snapshot
+func handleGetStorageGroupSnapshots(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		writeError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if InducedErrors.GetStorageGroupSnapshotError {
+		writeError(w, "Could not get StorageGroup Snapshots: induced error", http.StatusBadRequest)
+		return
+	}
+	if r.Method == http.MethodGet {
+		names := make([]string, 1)
+		names = append(names, "sg_1_snap")
+		namesAndCounts := make([]types.SnapshotNameAndCounts, 1)
+		namesAndCounts = append(namesAndCounts, types.SnapshotNameAndCounts{
+			Name:               "name",
+			SnapshotCount:      1,
+			NewestTimestampUtc: 123,
+		})
+		sgSnap := &types.StorageGroupSnapshot{
+			Name:                   names,
+			SlSnapshotName:         names,
+			SnapshotNamesAndCounts: namesAndCounts,
+		}
+		writeJSON(w, sgSnap)
+	} else {
+		sgCreateSnap := &types.StorageGroupSnap{
+			Name:       "sg_1_snap",
+			Generation: 1,
+			SnapID:     2,
+			Timestamp:  "1234",
+		}
+		writeJSON(w, sgCreateSnap)
+	}
 }
 
 // GET univmax/restapi/100/replication/symmetrix/{symID}/rdf_director/{dir}/port?online=true

--- a/replication.go
+++ b/replication.go
@@ -1,0 +1,258 @@
+/*
+ Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package pmax
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	types "github.com/dell/gopowermax/v2/types/v100"
+	log "github.com/sirupsen/logrus"
+)
+
+// The follow constants are for internal use within the pmax library.
+const (
+	Replication = "replication/"
+	SnapID      = "/snapid"
+)
+
+// SnapshotAction A list of possible Snapshot actions.
+type SnapshotAction string
+
+// Snapshot Actions
+const (
+	Restore       SnapshotAction = "Restore"       // Restores a snapshot generation
+	SetTimeToLive SnapshotAction = "SetTimeToLive" // Set the number of days or hours for a snapshot generation before it auto-terminates
+	SetSecure     SnapshotAction = "SetSecure"     // Set the number of days or hours for a snapshot generation to be secure before it auto-terminates
+	Link          SnapshotAction = "Link"          // Link a snapshot generation
+	Relink        SnapshotAction = "Relink"        // Relink a snapshot generation
+	Unlink        SnapshotAction = "Unlink"        // Unlink a snapshot generation
+	SetMode       SnapshotAction = "SetMode"       // Set the mode of a linked snapshot generation
+	Rename        SnapshotAction = "Rename"        // Rename a snapshot
+	Persist       SnapshotAction = "Persist"       // Persist a snapshot policy snapshot
+)
+
+// GetStorageGroupSnapshots Get All Storage Group Snapshots
+func (c *Client) GetStorageGroupSnapshots(ctx context.Context, symID string, storageGroupID string, exludeManualSnaps bool, exludeSlSnaps bool) (*types.StorageGroupSnapshot, error) {
+	defer c.TimeSpent("GetStorageGroupSnapshots", time.Now())
+	query := ""
+	if exludeManualSnaps && exludeSlSnaps {
+		query = "?exclude_manual_snaps=true&exclude_sl_snaps=true"
+	} else if exludeManualSnaps {
+		query = "?exclude_manual_snap=true"
+	} else if exludeSlSnaps {
+		query = "?exclude_sl_snaps=true"
+	}
+
+	URL := c.urlPrefix() + Replication + SymmetrixX + symID + XStorageGroup + "/" + storageGroupID + XSnapshot + query
+
+	ctx, cancel := c.GetTimeoutContext(ctx)
+	defer cancel()
+	resp, err := c.api.DoAndGetResponseBody(
+		ctx, http.MethodGet, URL, c.getDefaultHeaders(), nil)
+	if err != nil {
+		log.Error("GetStorageGroupSnapshots failed: " + err.Error())
+		return nil, err
+	}
+	if err = c.checkResponse(resp); err != nil {
+		return nil, err
+	}
+
+	snapshots := &types.StorageGroupSnapshot{}
+	decoder := json.NewDecoder(resp.Body)
+
+	if err = decoder.Decode(snapshots); err != nil {
+		return nil, err
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	return snapshots, nil
+}
+
+// GetStorageGroupSnapshotSnapIds Get a list of Snapids for a particular snapshot
+func (c *Client) GetStorageGroupSnapshotSnapIds(ctx context.Context, symID string, storageGroupID string, snapshotID string) (*types.SnapID, error) {
+	defer c.TimeSpent("GetStorageGroupSnapshotSnapIds", time.Now())
+	URL := c.urlPrefix() + Replication + SymmetrixX + symID + XStorageGroup + "/" + storageGroupID + XSnapshot + "/" + snapshotID + SnapID
+
+	ctx, cancel := c.GetTimeoutContext(ctx)
+	defer cancel()
+	resp, err := c.api.DoAndGetResponseBody(
+		ctx, http.MethodGet, URL, c.getDefaultHeaders(), nil)
+	if err != nil {
+		log.Error("GetStorageGroupSnapshotSnapIds failed: " + err.Error())
+		return nil, err
+	}
+	if err = c.checkResponse(resp); err != nil {
+		return nil, err
+	}
+
+	snapids := &types.SnapID{}
+	decoder := json.NewDecoder(resp.Body)
+
+	if err = decoder.Decode(snapids); err != nil {
+		return nil, err
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	log.Info(fmt.Sprintf("Successfully Fetched Snapids for StorageGroup %s", storageGroupID))
+	return snapids, nil
+}
+
+// GetStorageGroupSnapshotSnap Get the details of a storage group snapshot snap
+func (c *Client) GetStorageGroupSnapshotSnap(ctx context.Context, symID string, storageGroupID string, snapshotID, snapID string) (*types.StorageGroupSnap, error) {
+	defer c.TimeSpent("GetStorageGroupSnapshotSnapIds", time.Now())
+	URL := c.urlPrefix() + Replication + SymmetrixX + symID + XStorageGroup + "/" + storageGroupID + XSnapshot + "/" + snapshotID + SnapID + "/" + snapID
+
+	ctx, cancel := c.GetTimeoutContext(ctx)
+	defer cancel()
+	resp, err := c.api.DoAndGetResponseBody(
+		ctx, http.MethodGet, URL, c.getDefaultHeaders(), nil)
+	if err != nil {
+		log.Error("GetStorageGroupSnapshotSnapIds failed: " + err.Error())
+		return nil, err
+	}
+	if err = c.checkResponse(resp); err != nil {
+		return nil, err
+	}
+
+	snap := &types.StorageGroupSnap{}
+	decoder := json.NewDecoder(resp.Body)
+
+	if err = decoder.Decode(snap); err != nil {
+		return nil, err
+	}
+	err = resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	log.Info(fmt.Sprintf("Successfully Fetched Snapids for StorageGroup %s", storageGroupID))
+	return snap, nil
+}
+
+// CreateStorageGroupSnapshot Create a Storage Group Snapshot
+func (c *Client) CreateStorageGroupSnapshot(ctx context.Context, symID string, storageGroupID string, payload *types.CreateStorageGroupSnapshot) (*types.StorageGroupSnap, error) {
+	defer c.TimeSpent("CreateStorageGroupSnapshot", time.Now())
+	ifDebugLogPayload(payload)
+	URL := c.urlPrefix() + Replication + SymmetrixX + symID + XStorageGroup + "/" + storageGroupID + XSnapshot
+	ctx, cancel := c.GetTimeoutContext(ctx)
+	defer cancel()
+	snap := &types.StorageGroupSnap{}
+	err := c.api.Post(ctx, URL, c.getDefaultHeaders(), payload, snap)
+	if err != nil {
+		log.Error("CreateStorageGroupSnapshot failed: " + err.Error())
+		return nil, err
+	}
+	log.Info("Successfully created CreateStorageGroupSnapshot")
+	return snap, nil
+}
+
+// ModifyStorageGroupSnapshot Modify a Storage Group Snapshot snap
+func (c *Client) ModifyStorageGroupSnapshot(ctx context.Context, symID string, storageGroupID string, snapshotID string, snapID string, payload *types.ModifyStorageGroupSnapshot) (*types.StorageGroupSnap, error) {
+	defer c.TimeSpent("ModifyStorageGroupSnapshot", time.Now())
+	URL := c.urlPrefix() + Replication + SymmetrixX + symID + XStorageGroup + "/" + storageGroupID + XSnapshot + "/" + snapshotID + SnapID + "/" + snapID
+	ctx, cancel := c.GetTimeoutContext(ctx)
+	defer cancel()
+	snap := &types.StorageGroupSnap{}
+
+	ifDebugLogPayload(payload)
+	var putPayload interface{}
+	switch payload.Action {
+	case string(Restore):
+		putPayload = &types.RestoreStorageGroupSnapshot{
+			Action:          payload.Action,
+			ExecutionOption: payload.ExecutionOption,
+			Restore:         payload.Restore,
+		}
+	case string(Link):
+		putPayload = &types.LinkStorageGroupSnapshot{
+			Action:          payload.Action,
+			ExecutionOption: payload.ExecutionOption,
+			Link:            payload.Link,
+		}
+	case string(Relink):
+		putPayload = &types.RelinkStorageGroupSnapshot{
+			Action:          payload.Action,
+			ExecutionOption: payload.ExecutionOption,
+			Relink:          payload.Relink,
+		}
+	case string(Unlink):
+		putPayload = &types.UnlinkStorageGroupSnapshot{
+			Action:          payload.Action,
+			ExecutionOption: payload.ExecutionOption,
+			Unlink:          payload.Unlink,
+		}
+	case string(SetMode):
+		putPayload = &types.SetModeStorageGroupSnapshot{
+			Action:          payload.Action,
+			ExecutionOption: payload.ExecutionOption,
+			SetMode:         payload.SetMode,
+		}
+	case string(Rename):
+		putPayload = &types.RenameStorageGroupSnapshot{
+			Action:          payload.Action,
+			ExecutionOption: payload.ExecutionOption,
+			Rename:          payload.Rename,
+		}
+	case string(SetTimeToLive):
+		putPayload = &types.TimeToLiveStorageGroupSnapshot{
+			Action:          payload.Action,
+			ExecutionOption: payload.ExecutionOption,
+			TimeToLive:      payload.TimeToLive,
+		}
+	case string(SetSecure):
+		putPayload = &types.SecureStorageGroupSnapshot{
+			Action:          payload.Action,
+			ExecutionOption: payload.ExecutionOption,
+			Secure:          payload.Secure,
+		}
+	case string(Persist):
+		putPayload = &types.PersistStorageGroupSnapshot{
+			Action:          payload.Action,
+			ExecutionOption: payload.ExecutionOption,
+			Persist:         payload.Persist,
+		}
+	}
+	err := c.api.Put(
+		ctx, URL, c.getDefaultHeaders(), putPayload, snap)
+
+	if err != nil {
+		log.Error("ModifyStorageGroupSnapshot failed: " + err.Error())
+		return nil, err
+	}
+	log.Info("Successfully created ModifyStorageGroupSnapshot")
+	return snap, nil
+}
+
+// DeleteStorageGroupSnapshot Delete a Storage Group Snapshot snap
+func (c *Client) DeleteStorageGroupSnapshot(ctx context.Context, symID string, storageGroupID string, snapshotID string, snapID string) error {
+	defer c.TimeSpent("DeleteStorageGroupSnapshot", time.Now())
+	URL := c.urlPrefix() + Replication + SymmetrixX + symID + XStorageGroup + "/" + storageGroupID + XSnapshot + "/" + snapshotID + SnapID + "/" + snapID
+	ctx, cancel := c.GetTimeoutContext(ctx)
+	defer cancel()
+	err := c.api.Delete(ctx, URL, c.getDefaultHeaders(), nil)
+	if err != nil {
+		log.Error("Error in Delete Storage Group Snapshot: " + err.Error())
+	} else {
+		log.Info(fmt.Sprintf("Successfully deleted volume: %s", snapID))
+	}
+	return err
+}

--- a/sloprovisioning.go
+++ b/sloprovisioning.go
@@ -32,7 +32,6 @@ import (
 // The follow constants are for internal use within the pmax library.
 const (
 	SLOProvisioningX       = "sloprovisioning/"
-	Replication            = "replication/"
 	SnapshotPolicy         = "/snapshot_policy"
 	SymmetrixX             = "symmetrix/"
 	IteratorX              = "common/Iterator/"

--- a/types/v100/snapshot.go
+++ b/types/v100/snapshot.go
@@ -171,6 +171,231 @@ type VolumeSnapshotGenerations struct {
 	VolumeSnapshotLink   []VolumeSnapshotLink   `json:"snapshotLnk,omitempty"`
 }
 
+// SnapshotNameAndCounts object for storage group snapshots
+type SnapshotNameAndCounts struct {
+	Name               string `json:"name"`
+	SnapshotCount      int64  `json:"snapshot_count"`
+	NewestTimestampUtc int64  `json:"newest_timestamp_utc"`
+}
+
+// StorageGroupSnapshot contains a list of storage group snapshots
+type StorageGroupSnapshot struct {
+	Name                   []string                `json:"name"`
+	SlSnapshotName         []string                `json:"sl_snapshot_name"`
+	SnapshotNamesAndCounts []SnapshotNameAndCounts `json:"snapshot_names_and_counts"`
+}
+
+// StorageGroupSnap a PowerMax Snap Object
+type StorageGroupSnap struct {
+	Name                    string               `json:"name"`
+	Generation              int64                `json:"generation"`
+	SnapID                  int64                `json:"snapid"`
+	Timestamp               string               `json:"timestamp"`
+	TimestampUtc            int64                `json:"timestamp_utc"`
+	State                   []string             `json:"state"`
+	NumSourceVolumes        int32                `json:"num_source_volumes"`
+	SourceVolume            []SourceVolume       `json:"source_volume"`
+	NumStorageGroupVolumes  int32                `json:"num_storage_group_volumes"`
+	Tracks                  int64                `json:"tracks"`
+	NotSharedTracks         int64                `json:"non_shared_tracks"`
+	TimeToLiveExpiryDate    string               `json:"time_to_live_expiry_date"`
+	SecureExpiryDate        string               `json:"secure_expiry_date"`
+	Expired                 bool                 `json:"expired"`
+	Linked                  bool                 `json:"linked"`
+	Restored                bool                 `json:"restored"`
+	LinkedStorageGroupNames []string             `json:"linked_storage_group_names"`
+	Persistent              bool                 `json:"persistent"`
+	LinkedStorageGroups     []LinkedStorageGroup `json:"linked_storage_group"`
+}
+
+// LinkedStorageGroup linked storage group
+type LinkedStorageGroup struct {
+	Name                       string `json:"name"`
+	SourceVolumeName           string `json:"source_volume_name"`
+	LinkedVolumeName           string `json:"linked_volume_name"`
+	Tracks                     int64  `json:"tracks"`
+	TrackSize                  int64  `json:"trackSize"`
+	PercentageCopied           int64  `json:"percentageCopied"`
+	Defined                    bool   `json:"defined"`
+	BackgroundDefineInProgress bool   `json:"background_define_in_progress"`
+}
+
+// SourceVolume the source of a volume
+type SourceVolume struct {
+	Name       string  `json:"name"`
+	Capacity   int64   `json:"capacity"`
+	CapacityGb float64 `json:"capacity_gb"`
+}
+
+// CreateStorageGroupSnapshot object to create a storage group snapshot
+type CreateStorageGroupSnapshot struct {
+	SnapshotName    string `json:"snapshotName"`
+	ExecutionOption string `json:"executionOption"`
+	TimeToLive      int32  `json:"timeToLive,omitempty"`
+	Secure          int32  `json:"secure,omitempty"`
+	TimeInHours     bool   `json:"force,omitempty"`
+	Star            bool   `json:"start,omitempty"`
+	Bothsides       bool   `json:"bothsides,omitempty"`
+}
+
+// ModifyStorageGroupSnapshot Modify a Storage Group snap
+type ModifyStorageGroupSnapshot struct {
+	ExecutionOption string                   `json:"executionOption,omitempty"`
+	Action          string                   `json:"action"`
+	Restore         RestoreSnapshotAction    `json:"restore,omitempty"`
+	Link            LinkSnapshotAction       `json:"link,omitempty"`
+	Relink          RelinkSnapshotAction     `json:"relink,omitempty"`
+	Unlink          UnlinkSnapshotAction     `json:"unlink,omitempty"`
+	SetMode         SetModeSnapshotAction    `json:"set_mode,omitempty"`
+	Rename          RenameSnapshotAction     `json:"rename,omitempty"`
+	TimeToLive      TimeToLiveSnapshotAction `json:"time_to_live,omitempty"`
+	Secure          SecureSnapshotAction     `json:"secure,omitempty"`
+	Persist         PresistSnapshotAction    `json:"persist,omitempty"`
+}
+
+// RenameStorageGroupSnapshot Modify a Storage Group snap to rename
+type RenameStorageGroupSnapshot struct {
+	ExecutionOption string               `json:"executionOption,omitempty"`
+	Action          string               `json:"action"`
+	Rename          RenameSnapshotAction `json:"rename"`
+}
+
+// RestoreStorageGroupSnapshot Modify a Storage Group snap to restore
+type RestoreStorageGroupSnapshot struct {
+	ExecutionOption string                `json:"executionOption,omitempty"`
+	Action          string                `json:"action"`
+	Restore         RestoreSnapshotAction `json:"restore"`
+}
+
+// LinkStorageGroupSnapshot Modify a Storage Group snap to link
+type LinkStorageGroupSnapshot struct {
+	ExecutionOption string             `json:"executionOption,omitempty"`
+	Action          string             `json:"action"`
+	Link            LinkSnapshotAction `json:"link"`
+}
+
+// RelinkStorageGroupSnapshot Modify a Storage Group snap to relink
+type RelinkStorageGroupSnapshot struct {
+	ExecutionOption string               `json:"executionOption,omitempty"`
+	Action          string               `json:"action"`
+	Relink          RelinkSnapshotAction `json:"relink"`
+}
+
+// UnlinkStorageGroupSnapshot Modify a Storage Group snap to unlink
+type UnlinkStorageGroupSnapshot struct {
+	ExecutionOption string               `json:"executionOption,omitempty"`
+	Action          string               `json:"action"`
+	Unlink          UnlinkSnapshotAction `json:"unlink"`
+}
+
+// SetModeStorageGroupSnapshot Modify a Storage Group snaps set mode
+type SetModeStorageGroupSnapshot struct {
+	ExecutionOption string                `json:"executionOption,omitempty"`
+	Action          string                `json:"action"`
+	SetMode         SetModeSnapshotAction `json:"set_mode"`
+}
+
+// TimeToLiveStorageGroupSnapshot Modify a Storage Group snaps time to live
+type TimeToLiveStorageGroupSnapshot struct {
+	ExecutionOption string                   `json:"executionOption,omitempty"`
+	Action          string                   `json:"action"`
+	TimeToLive      TimeToLiveSnapshotAction `json:"time_to_live"`
+}
+
+// SecureStorageGroupSnapshot Modify a Storage Group snap be secure
+type SecureStorageGroupSnapshot struct {
+	ExecutionOption string               `json:"executionOption,omitempty"`
+	Action          string               `json:"action"`
+	Secure          SecureSnapshotAction `json:"secure"`
+}
+
+// PersistStorageGroupSnapshot Modify a Storage Group snap to persist
+type PersistStorageGroupSnapshot struct {
+	ExecutionOption string                `json:"executionOption,omitempty"`
+	Action          string                `json:"action"`
+	Persist         PresistSnapshotAction `json:"persist"`
+}
+
+// RestoreSnapshotAction an action on a Storage Group snap
+type RestoreSnapshotAction struct {
+	Force  bool `json:"force,omitempty"`
+	Star   bool `json:"star,omitempty"`
+	Remote bool `json:"remote,omitempty"`
+}
+
+// LinkSnapshotAction an action on a Storage Group snap
+type LinkSnapshotAction struct {
+	Force            bool   `json:"force,omitempty"`
+	Star             bool   `json:"star,omitempty"`
+	Remote           bool   `json:"remote,omitempty"`
+	StorageGroupName string `json:"storage_group_name"`
+	NoCompression    bool   `json:"no_compression,omitempty"`
+	Exact            bool   `json:"exact,omitempty"`
+	Copy             bool   `json:"copy,omitempty"`
+}
+
+// RelinkSnapshotAction an action on a Storage Group snap
+type RelinkSnapshotAction struct {
+	Force            bool   `json:"force,omitempty"`
+	Star             bool   `json:"star,omitempty"`
+	Remote           bool   `json:"remote,omitempty"`
+	StorageGroupName string `json:"storage_group_name"`
+	Exact            bool   `json:"exact,omitempty"`
+	Copy             bool   `json:"copy,omitempty"`
+}
+
+// UnlinkSnapshotAction an action on a Storage Group snap
+type UnlinkSnapshotAction struct {
+	Force            bool   `json:"force,omitempty"`
+	Star             bool   `json:"star,omitempty"`
+	Symforce         bool   `json:"symforce,omitempty"`
+	StorageGroupName string `json:"storage_group_name"`
+}
+
+// SetModeSnapshotAction an action on a Storage Group snap
+type SetModeSnapshotAction struct {
+	Force            bool   `json:"force,omitempty"`
+	Star             bool   `json:"star,omitempty"`
+	StorageGroupName string `json:"storage_group_name"`
+	Copy             bool   `json:"copy,omitempty"`
+}
+
+// RenameSnapshotAction an action on a Storage Group snap
+type RenameSnapshotAction struct {
+	Force                       bool   `json:"force,omitempty"`
+	Star                        bool   `json:"star,omitempty"`
+	NewStorageGroupSnapshotName string `json:"new_snapshot_name"`
+}
+
+// TimeToLiveSnapshotAction an action on a Storage Group snap
+type TimeToLiveSnapshotAction struct {
+	Force       bool  `json:"force,omitempty"`
+	Star        bool  `json:"star,omitempty"`
+	TimeToLive  int32 `json:"time_to_live,omitempty"`
+	TimeInHours bool  `json:"time_in_hours,omitempty"`
+}
+
+// SecureSnapshotAction an action on a Storage Group snap
+type SecureSnapshotAction struct {
+	Force       bool  `json:"force,omitempty"`
+	Star        bool  `json:"star,omitempty"`
+	Secure      int32 `json:"secure,omitempty"`
+	TimeInHours bool  `json:"time_in_hours,omitempty"`
+}
+
+// PresistSnapshotAction an action on a Storage Group snap
+type PresistSnapshotAction struct {
+	Force   bool `json:"force,omitempty"`
+	Star    bool `json:"star,omitempty"`
+	Remote  bool `json:"remote,omitempty"`
+	Persist bool `json:"persist,omitempty"`
+}
+
+// SnapID list of snap ids related to a Storage Group snapshot
+type SnapID struct {
+	SnapIds []int64 `json:"snapids"`
+}
+
 // SymDevice list of devices on a particular symmetrix system
 type SymDevice struct {
 	SymmetrixID string     `json:"symmetrixId"`

--- a/unittest/pmax_replication.feature
+++ b/unittest/pmax_replication.feature
@@ -281,3 +281,64 @@ Feature: PMAX replication test
     | "00007" | "cannot be found"              |   ""      | "none"                   |
     | "00001" | "ignored as it is not managed" | "ignored" | "none"                   |
     | "00001" | "induced error"                |   ""      | "GetPrivVolumeByIDError" |
+
+  Scenario Outline: Testing GetStorageGroupSnapshots
+    Given a valid connection
+    And I call CreateStorageGroupSnapshot with "sg_1"
+    And I induce error <induced>
+    When I call GetStorageGroupSnapshots with <storageGroupID>
+    Then the error message contains <errormsg>
+    And I should get storage group snapshot information if no error
+  
+    Examples:
+    | storageGroupID   | errormsg             | arrays    | induced                        |
+    | "sg_1"           | "none"               |   ""      | "none"                         |
+    | "sg_1"           | "induced error"      |   ""      | "GetStorageGroupSnapshotError" |
+
+  Scenario Outline: Testing GetStorageGroupSnapshotSnapIds
+    Given a valid connection
+    And I call CreateStorageGroupSnapshot with "sg_1"
+    And I induce error <induced>
+    When I call GetStorageGroupSnapshotSnapIds with <storageGroupID> and <snapshotID>
+    Then the error message contains <errormsg>
+    And I should get storage group snapshot snap ids if no error
+  
+    Examples:
+    | storageGroupID   | snapshotID | errormsg             | arrays    | induced                            |
+    | "sg_1"           | "123"      | "none"               |   ""      | "none"                             |
+    | "sg_1"           | "123"      | "induced error"      |   ""      | "GetStorageGroupSnapshotSnapError" |
+
+  Scenario Outline: Testing GetStorageGroupSnapshotSnap
+    Given a valid connection
+    And I call CreateStorageGroupSnapshot with "sg_1"
+    And I induce error <induced>
+    When I call GetStorageGroupSnapshotSnap with <storageGroupID> and <snapshotID> and <snapID>
+    Then the error message contains <errormsg>
+    And I should get storage group snapshot snap detail information if no error
+  
+    Examples:
+    | storageGroupID   | snapshotID | snapID | errormsg             | arrays    | induced                                  |
+    | "sg_1"           | "123"      | "321"  | "none"               |   ""      | "none"                                   |
+    | "sg_1"           | "123"      | "321"  | "induced error"      |   ""      | "GetStorageGroupSnapshotSnapDetailError" |
+
+    
+  Scenario Outline: Testing ModifyStorageGroupSnapshot
+    Given a valid connection
+    And I call CreateStorageGroupSnapshot with "sg_1"
+    And I induce error <induced>
+    When I call ModifyStorageGroupSnapshot with <storageGroupID> and <snapshotID> and <snapID> and action <action>
+    Then the error message contains <errormsg>
+    And I should modify storage group snapshot snap if no error
+  
+    Examples:
+    | storageGroupID   | snapshotID | snapID | action       | errormsg             | arrays    | induced                                  |
+    | "sg_1"           | "123"      | "321"  | "rename"     | "none"               |   ""      | "none"                                   |
+    | "sg_1"           | "123"      | "321"  | "restore"    | "none"               |   ""      | "none"                                   |
+    | "sg_1"           | "123"      | "321"  | "link"       | "none"               |   ""      | "none"                                   |
+    | "sg_1"           | "123"      | "321"  | "relink"     | "none"               |   ""      | "none"                                   |
+    | "sg_1"           | "123"      | "321"  | "unlink"     | "none"               |   ""      | "none"                                   |
+    | "sg_1"           | "123"      | "321"  | "setmode"    | "none"               |   ""      | "none"                                   |
+    | "sg_1"           | "123"      | "321"  | "timeToLive" | "none"               |   ""      | "none"                                   |
+    | "sg_1"           | "123"      | "321"  | "secure"     | "none"               |   ""      | "none"                                   |
+    | "sg_1"           | "123"      | "321"  | "persist"    | "none"               |   ""      | "none"                                   |
+    | "sg_1"           | "123"      | "321"  | "rename"     | "induced error"      |   ""      | "GetStorageGroupSnapshotSnapModifyError" |


### PR DESCRIPTION
# Description
- Add CRUD Operations for Storage Group Snapshots.

# GitHub Issues
List the GitHub issues impacted by this PR:
| GitHub Issue # |
| https://github.com/dell/csm/issues/770 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained at least 90% code coverage?
- [x] Backward compatibility is not broken

# How Has This Been Tested?

## Integration Test
```
go test -timeout 30s -run ^TestCrudStorageGroupSnapshot github.com/dell/gopowermax/v2/inttest
ok      github.com/dell/gopowermax/v2/inttest   19.584s
```

## Unit Tests
```
556 scenarios (556 passed)
3692 steps (3692 passed)
35.7934414s
testing: warning: no tests to run
PASS
        command-line-arguments  coverage: 83.2% of statements
status 0
ok      command-line-arguments  36.656s coverage: 83.2% of statements [no tests to run]
```
## Linting
```
$ make check
gofmt -w authenticate.go interface.go system.go sloprovisioning.go VolumeSnapshot.go VolumeReplication.go metrics.go ArrayMigration.go unit_test.go unit_steps_test.go inttest/pmax_integration_test.go inttest/pmax_replication_integration_test.go
golint -set_exit_status
go vet
```
