### PR TITLE
Updated JSON attributes for Port and Initiators 

### DIFF
--- a/types/v100/types.go
+++ b/types/v100/types.go
@@ -228,7 +228,7 @@ type PortGroup struct {
 	PortGroupID        string    `json:"portGroupId"`
 	SymmetrixPortKey   []PortKey `json:"symmetrixPortKey"`
 	NumberPorts        int64     `json:"num_of_ports"`
-	NumberMaskingViews int64     `json:"number_of_masking_views"`
+	NumberMaskingViews int64     `json:"num_of_masking_views"`
 	PortGroupType      string    `json:"type"`
 	MaskingView        []string  `json:"maskingview"`
 	TestID             string    `json:"testId"`
@@ -269,7 +269,7 @@ type Initiator struct {
 	FlagsInEffect        string    `json:"flags_in_effect"`
 	NumberVols           int64     `json:"num_of_vols"`
 	NumberHostGroups     int64     `json:"num_of_host_groups"`
-	NumberMaskingViews   int64     `json:"number_of_masking_views"`
+	NumberMaskingViews   int64     `json:"num_of_masking_views"`
 	MaskingView          []string  `json:"maskingview"`
 	PowerPathHosts       []string  `json:"powerpathhosts"`
 	NumberPowerPathHosts int64     `json:"num_of_powerpath_hosts"`


### PR DESCRIPTION
# Description
NumberMaskingViews is wrongly updated in JSON 

num_of_masking_views | array | Port namesInitiator Ids that contain greater than(">1"), Less than("<1") or equal to the specified number of masking views
-- | -- | --
num_of_masking_views | string | (Front End Port Only) Port names that contain greater than(">1"), Less than("<1") or equal to the specified num_of_masking_views

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/808 |

# Checklist:

- [X] Have you run format,vet & lint checks against your submission?
- [X] Have you made sure that the code compiles?
- [X] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Have you maintained at least 90% code coverage?
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
