### PR TITLE
Improve code coverage

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -35,17 +35,17 @@ import (
 
 type stubTypeWithMetaData struct{}
 
-// MyReader is an io.ReadCloser implementation for writing
+// httpBodyReadCloser is an io.ReadCloser implementation for writing
 // the body of an http request
-type MyReader struct {
+type httpBodyReadCloser struct {
 	reader io.Reader
 }
 
-func (r *MyReader) Read(p []byte) (int, error) {
+func (r *httpBodyReadCloser) Read(p []byte) (int, error) {
 	return r.reader.Read(p)
 }
 
-func (r *MyReader) Close() error {
+func (r *httpBodyReadCloser) Close() error {
 	return nil
 }
 
@@ -473,7 +473,7 @@ func TestDoAndGetResponseBody(t *testing.T) {
 			method:  http.MethodPost,
 			uri:     "/test",
 			headers: map[string]string{"Custom-Header": "application/json"},
-			body: &MyReader{
+			body: &httpBodyReadCloser{
 				reader: strings.NewReader("Success"),
 			},
 			mockResponse: &http.Response{

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -35,6 +35,8 @@ import (
 
 type stubTypeWithMetaData struct{}
 
+// MyReader is an io.ReadCloser implementation for writing
+// the body of an http request
 type MyReader struct {
 	reader io.Reader
 }

--- a/authenticate.go
+++ b/authenticate.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/authenticate.go
+++ b/authenticate.go
@@ -37,17 +37,25 @@ type Client struct {
 	version        string
 	symmetrixID    string
 	contextTimeout time.Duration
+	opts           clientOpts
+	headers        clientHeaders
+}
+
+type clientOpts struct {
+	logResponseTimes bool
+}
+
+type clientHeaders struct {
+	accept          string
+	contentType     string
+	applicationType string
 }
 
 var (
-	errNilReponse    = errors.New("nil response from API")
-	errBodyRead      = errors.New("error reading body")
-	errNoLink        = errors.New("Error: problem finding link")
-	debug, _         = strconv.ParseBool(os.Getenv("X_CSI_POWERMAX_DEBUG"))
-	accHeader        string
-	conHeader        string
-	applicationType  string
-	logResponseTimes bool
+	errNilReponse = errors.New("nil response from API")
+	errBodyRead   = errors.New("error reading body")
+	errNoLink     = errors.New("Error: problem finding link")
+	debug, _      = strconv.ParseBool(os.Getenv("X_CSI_POWERMAX_DEBUG"))
 	// PmaxTimeout is the timeout value for pmax calls.
 	// If Unisphere fails to answer within this period, an error will be returned.
 	defaultPmaxTimeout = 10 * time.Minute
@@ -139,7 +147,7 @@ func NewClientWithArgs(
 	useCerts bool,
 	certFile string,
 ) (client Pmax, err error) {
-	logResponseTimes, _ = strconv.ParseBool(os.Getenv("X_CSI_POWERMAX_RESPONSE_TIMES"))
+	setLogResponseTimes, _ := strconv.ParseBool(os.Getenv("X_CSI_POWERMAX_RESPONSE_TIMES"))
 
 	contextTimeout := defaultPmaxTimeout
 	if timeoutStr := os.Getenv("X_CSI_UNISPHERE_TIMEOUT"); timeoutStr != "" {
@@ -157,7 +165,7 @@ func NewClientWithArgs(
 		"useCerts":         useCerts,
 		"version":          DefaultAPIVersion,
 		"debug":            debug,
-		"logResponseTimes": logResponseTimes,
+		"logResponseTimes": setLogResponseTimes,
 	}
 
 	doLog(log.WithFields(fields).Debug, "pmax client init")
@@ -174,17 +182,13 @@ func NewClientWithArgs(
 		CertFile: certFile,
 	}
 
-	if applicationType != "" {
-		log.Debug(fmt.Sprintf("Application type already set to: %s, Resetting it to: %s",
-			applicationType, applicationName))
-	}
-	applicationType = applicationName
-
 	ac, err := api.New(endpoint, opts, debug)
 	if err != nil {
 		doLog(log.WithError(err).Error, "Unable to create HTTP client")
 		return nil, err
 	}
+
+	acceptHeader := fmt.Sprintf("%s;version=%s", api.HeaderValContentTypeJSON, DefaultAPIVersion)
 
 	client = &Client{
 		api: ac,
@@ -194,11 +198,15 @@ func NewClientWithArgs(
 		allowedArrays:  []string{},
 		version:        DefaultAPIVersion,
 		contextTimeout: contextTimeout,
+		opts: clientOpts{
+			logResponseTimes: setLogResponseTimes,
+		},
+		headers: clientHeaders{
+			accept:          acceptHeader,
+			contentType:     acceptHeader,
+			applicationType: applicationName,
+		},
 	}
-
-	accHeader = api.HeaderValContentTypeJSON
-	accHeader = fmt.Sprintf("%s;version=%s", api.HeaderValContentTypeJSON, DefaultAPIVersion)
-	conHeader = accHeader
 
 	return client, nil
 }
@@ -218,11 +226,11 @@ func (c *Client) SetContextTimeout(timeout time.Duration) Pmax {
 
 func (c *Client) getDefaultHeaders() map[string]string {
 	headers := make(map[string]string)
-	headers["Accept"] = accHeader
-	if applicationType != "" {
-		headers["Application-Type"] = applicationType
+	headers["Accept"] = c.headers.accept
+	if c.headers.applicationType != "" {
+		headers["Application-Type"] = c.headers.applicationType
 	}
-	headers["Content-Type"] = conHeader
+	headers["Content-Type"] = c.headers.contentType
 	basicAuthString := basicAuth(c.configConnect.Username, c.configConnect.Password)
 	headers["Authorization"] = "Basic " + basicAuthString
 	if c.symmetrixID != "" {

--- a/interface.go
+++ b/interface.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -387,6 +387,10 @@ type Pmax interface {
 	DeleteMigrationEnvironment(ctx context.Context, localSymID, remoteSymID string) error
 	// GetMigrationEnvironment returns a migration environment
 	GetMigrationEnvironment(ctx context.Context, localSymID, remoteSymID string) (*types.MigrationEnv, error)
+	// MigrateStorageGroup creates a Storage Group given the storageGroupID (name), srpID (storage resource pool), service level, and boolean for thick volumes.
+	// If srpID is "None" then serviceLevel and thickVolumes settings are ignored
+	MigrateStorageGroup(ctx context.Context, symID, storageGroupID, srpID, serviceLevel string, thickVolumes bool) (*types.StorageGroup, error)
+
 	// GetStorageGroupMigration returns migration sessions on the array
 	GetStorageGroupMigration(ctx context.Context, localSymID string) (*types.MigrationStorageGroups, error)
 	// GetStorageGroupMigrationByID returns migration details for a storage group

--- a/inttest/pmax_integration_test.go
+++ b/inttest/pmax_integration_test.go
@@ -2070,6 +2070,22 @@ func TestGetISCSITargets(t *testing.T) {
 	fmt.Printf("Targets: %v\n", targets)
 }
 
+func TestGetNVMeTCPTargets(t *testing.T) {
+	if client == nil {
+		err := getClient()
+		if err != nil {
+			t.Error(err.Error())
+			return
+		}
+	}
+	targets, err := client.GetNVMeTCPTargets(context.TODO(), symmetrixID)
+	if err != nil {
+		t.Error("Error calling GetNVMeTCPTargets " + err.Error())
+		return
+	}
+	fmt.Printf("Targets: %v\n", targets)
+}
+
 func TestExpandVolume(t *testing.T) {
 	if client == nil {
 		err := getClient()

--- a/inttest/pmax_integration_test.go
+++ b/inttest/pmax_integration_test.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/migration_test.go
+++ b/migration_test.go
@@ -1,0 +1,532 @@
+/*
+Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package pmax
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	types "github.com/dell/gopowermax/v2/types/v100"
+)
+
+const (
+	urlPrefix = "/univmax/restapi/100/"
+)
+
+func TestModifyMigrationSession(t *testing.T) {
+	type testCase struct {
+		server         *httptest.Server
+		localSymID     string
+		storageGroupID string
+		expectedErr    error
+	}
+
+	cases := map[string]testCase{
+		"get one device success": {
+			localSymID:     "mock-local-sym-id",
+			storageGroupID: "mock-storage-group-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				url := fmt.Sprintf("%s%s%s%s%s/%s", urlPrefix, XMigration, SymmetrixX, "mock-local-sym-id", XStorageGroup, "mock-storage-group-id")
+				switch req.RequestURI {
+				case url:
+					resp.WriteHeader(http.StatusOK)
+					response := &types.ModifyMigrationSessionRequest{
+						Action:          "mock-action",
+						ExecutionOption: types.ExecutionOptionSynchronous,
+					}
+
+					content, err := json.Marshal(response)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					_, err = resp.Write(content)
+					if err != nil {
+						t.Fatal(err)
+					}
+				default:
+					resp.WriteHeader(http.StatusNoContent)
+				}
+			})),
+			expectedErr: nil,
+		},
+		"bad request": {
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("bad request"),
+		},
+	}
+
+	for _, tc := range cases {
+		client, err := NewClientWithArgs(tc.server.URL, "", true, true, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = client.ModifyMigrationSession(context.TODO(), tc.localSymID, "mock-action", tc.storageGroupID)
+		if err != nil {
+			if tc.expectedErr.Error() != err.Error() {
+				t.Fatal(err)
+			}
+		}
+
+		tc.server.Close()
+	}
+}
+
+func TestCreateMigrationEnvironment(t *testing.T) {
+	type testCase struct {
+		server         *httptest.Server
+		localSymID     string
+		storageGroupID string
+		expectedErr    error
+	}
+
+	cases := map[string]testCase{
+		"get one device success": {
+			localSymID: "mock-local-sym-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				url := fmt.Sprintf("%s%s%s%s", urlPrefix, XMigration, SymmetrixX, "mock-local-sym-id")
+				switch req.RequestURI {
+				case url:
+					resp.WriteHeader(http.StatusOK)
+					response := &types.CreateMigrationEnv{
+						OtherArrayID:    "mock-storage-group-id",
+						ExecutionOption: types.ExecutionOptionSynchronous,
+					}
+
+					content, err := json.Marshal(response)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					_, err = resp.Write(content)
+					if err != nil {
+						t.Fatal(err)
+					}
+				default:
+					resp.WriteHeader(http.StatusNoContent)
+				}
+			})),
+			expectedErr: nil,
+		},
+		"bad request": {
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("bad request"),
+		},
+	}
+
+	for _, tc := range cases {
+		client, err := NewClientWithArgs(tc.server.URL, "", true, true, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = client.CreateMigrationEnvironment(context.TODO(), tc.localSymID, tc.storageGroupID)
+		if err != nil {
+			if tc.expectedErr.Error() != err.Error() {
+				t.Fatal(err)
+			}
+		}
+
+		tc.server.Close()
+	}
+}
+
+func TestDeleteMigrationEnvironment(t *testing.T) {
+	type testCase struct {
+		server      *httptest.Server
+		localSymID  string
+		remoteSymID string
+		expectedErr error
+	}
+
+	cases := map[string]testCase{
+		"get one device success": {
+			localSymID:  "mock-local-sym-id",
+			remoteSymID: "mock-remote-sym-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				url := fmt.Sprintf("%s%s%s%s", urlPrefix, XMigration, SymmetrixX, "mock-local-sym-id")
+				switch req.RequestURI {
+				case url:
+					resp.WriteHeader(http.StatusOK)
+				default:
+					resp.WriteHeader(http.StatusNoContent)
+				}
+			})),
+			expectedErr: nil,
+		},
+		"bad request": {
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("bad request"),
+		},
+	}
+
+	for _, tc := range cases {
+		client, err := NewClientWithArgs(tc.server.URL, "", true, true, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = client.DeleteMigrationEnvironment(context.TODO(), tc.localSymID, tc.remoteSymID)
+		if err != nil {
+			if tc.expectedErr.Error() != err.Error() {
+				t.Fatal(err)
+			}
+		}
+
+		tc.server.Close()
+	}
+}
+
+func TestCreateSGMigrationByID(t *testing.T) {
+	type testCase struct {
+		server         *httptest.Server
+		localSymID     string
+		remoteSymID    string
+		storageGroupID string
+		expectedErr    error
+	}
+
+	cases := map[string]testCase{
+		"get one device success": {
+			localSymID:     "mock-local-sym-id",
+			remoteSymID:    "mock-remote-sym-id",
+			storageGroupID: "mock-storage-group-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				url := fmt.Sprintf("%s%s%s%s%s/%s", urlPrefix, XMigration, SymmetrixX, "mock-local-sym-id", XStorageGroup, "mock-storage-group-id")
+				switch req.RequestURI {
+				case url:
+					resp.WriteHeader(http.StatusOK)
+					response := types.CreateMigrationEnv{
+						OtherArrayID:    "mock-remote-sym-id",
+						ExecutionOption: types.ExecutionOptionSynchronous,
+					}
+
+					content, err := json.Marshal(response)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					_, err = resp.Write(content)
+					if err != nil {
+						t.Fatal(err)
+					}
+				default:
+					resp.WriteHeader(http.StatusNoContent)
+				}
+			})),
+			expectedErr: nil,
+		},
+		"bad request": {
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("bad request"),
+		},
+	}
+
+	for _, tc := range cases {
+		client, err := NewClientWithArgs(tc.server.URL, "", true, true, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = client.CreateSGMigration(context.TODO(), tc.localSymID, tc.remoteSymID, tc.storageGroupID)
+		if err != nil {
+			if tc.expectedErr.Error() != err.Error() {
+				t.Fatal(err)
+			}
+		}
+
+		tc.server.Close()
+	}
+}
+
+func TestMigrateStorageGroup(t *testing.T) {
+	type testCase struct {
+		server         *httptest.Server
+		localSymID     string
+		storageGroupID string
+		srpID          string
+		serviceLevel   string
+		thickVolumes   bool
+		expectedErr    error
+	}
+
+	cases := map[string]testCase{
+		"get one device success": {
+			localSymID:     "mock-local-sym-id",
+			storageGroupID: "mock-storage-group-id",
+			srpID:          "mock_SRP_1",
+			serviceLevel:   "mock-service-level",
+			thickVolumes:   true,
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				url := fmt.Sprintf("%s%s%s%s%s", urlPrefix, XMigration, SymmetrixX, "mock-local-sym-id", XStorageGroup)
+				switch req.RequestURI {
+				case url:
+					resp.WriteHeader(http.StatusOK)
+
+					sloParams := []types.SLOBasedStorageGroupParam{}
+					var snapshotPolicies []string
+
+					response := &types.CreateStorageGroupParam{
+						StorageGroupID:            "mock-storage-group-id",
+						SRPID:                     "mock_SRP_1",
+						Emulation:                 "mock-emulation",
+						ExecutionOption:           types.ExecutionOptionSynchronous,
+						SLOBasedStorageGroupParam: sloParams,
+						SnapshotPolicies:          snapshotPolicies,
+					}
+
+					content, err := json.Marshal(response)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					_, err = resp.Write(content)
+					if err != nil {
+						t.Fatal(err)
+					}
+				default:
+					resp.WriteHeader(http.StatusNoContent)
+				}
+			})),
+			expectedErr: nil,
+		},
+		"bad request": {
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("bad request"),
+		},
+	}
+
+	for _, tc := range cases {
+		client, err := NewClientWithArgs(tc.server.URL, "", true, true, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = client.MigrateStorageGroup(context.TODO(), tc.localSymID, tc.storageGroupID, tc.srpID, tc.serviceLevel, tc.thickVolumes)
+		if err != nil {
+			if tc.expectedErr.Error() != err.Error() {
+				t.Fatal(err)
+			}
+		}
+
+		tc.server.Close()
+	}
+}
+
+func TestGetStorageGroupMigrationByID(t *testing.T) {
+	type testCase struct {
+		server         *httptest.Server
+		localSymID     string
+		storageGroupID string
+		expectedErr    error
+	}
+
+	cases := map[string]testCase{
+		"get one device success": {
+			localSymID:     "mock-local-sym-id",
+			storageGroupID: "mock-storage-group-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				url := fmt.Sprintf("%s%s%s%s%s/%s", urlPrefix, XMigration, SymmetrixX, "mock-local-sym-id", XStorageGroup, "mock-storage-group-id")
+				switch req.RequestURI {
+				case url:
+					resp.WriteHeader(http.StatusOK)
+					response := &types.MigrationSession{
+						SourceArray:  "mock-local-sym-id",
+						TargetArray:  "mock-target-sym-id",
+						StorageGroup: "mock-storage-group-id",
+					}
+
+					content, err := json.Marshal(response)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					_, err = resp.Write(content)
+					if err != nil {
+						t.Fatal(err)
+					}
+				default:
+					resp.WriteHeader(http.StatusNoContent)
+				}
+			})),
+			expectedErr: nil,
+		},
+		"bad request": {
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("bad request"),
+		},
+	}
+
+	for _, tc := range cases {
+		client, err := NewClientWithArgs(tc.server.URL, "", true, true, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = client.GetStorageGroupMigrationByID(context.TODO(), tc.localSymID, tc.storageGroupID)
+		if err != nil {
+			if tc.expectedErr.Error() != err.Error() {
+				t.Fatal(err)
+			}
+		}
+
+		tc.server.Close()
+	}
+}
+
+func TestGetStorageGroupMigration(t *testing.T) {
+	type testCase struct {
+		server      *httptest.Server
+		localSymID  string
+		expectedErr error
+	}
+
+	cases := map[string]testCase{
+		"get one device success": {
+			localSymID: "mock-local-sym-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				queryParam := fmt.Sprintf("%s=%s", IncludeMigrations, "true")
+				url := fmt.Sprintf("%s%s%s%s%s%s", urlPrefix, XMigration, SymmetrixX, "mock-local-sym-id", XStorageGroup, queryParam)
+				switch req.RequestURI {
+				case url:
+					resp.WriteHeader(http.StatusOK)
+					response := &types.MigrationStorageGroups{
+						StorageGroupIDList: []string{"mock-storage-group-id"},
+						MigratingNameList:  []string{"mock-migrating-name"},
+					}
+
+					content, err := json.Marshal(response)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					_, err = resp.Write(content)
+					if err != nil {
+						t.Fatal(err)
+					}
+				default:
+					resp.WriteHeader(http.StatusNoContent)
+				}
+			})),
+			expectedErr: nil,
+		},
+		"bad request": {
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("bad request"),
+		},
+	}
+
+	for _, tc := range cases {
+		client, err := NewClientWithArgs(tc.server.URL, "", true, true, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = client.GetStorageGroupMigration(context.TODO(), tc.localSymID)
+		if err != nil {
+			if tc.expectedErr.Error() != err.Error() {
+				t.Fatal(err)
+			}
+		}
+
+		tc.server.Close()
+	}
+}
+
+func TestGetMigrationEnvironment(t *testing.T) {
+	type testCase struct {
+		server         *httptest.Server
+		localSymID     string
+		remoteSystemID string
+		expectedErr    error
+	}
+
+	cases := map[string]testCase{
+		"get one device success": {
+			localSymID:     "mock-local-sym-id",
+			remoteSystemID: "mock-remote-sym-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+				url := fmt.Sprintf("%s%s%s%s%s%s", urlPrefix, XMigration, SymmetrixX, "mock-local-sym-id", XEnvironment, "mock-remote-sym-id")
+				switch req.RequestURI {
+				case url:
+					resp.WriteHeader(http.StatusOK)
+					response := &types.MigrationEnv{
+						ArrayID:               "mock-local-sym-id",
+						StorageGroupCount:     2,
+						MigrationSessionCount: 2,
+						Local:                 true,
+					}
+
+					content, err := json.Marshal(response)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					_, err = resp.Write(content)
+					if err != nil {
+						t.Fatal(err)
+					}
+				default:
+					resp.WriteHeader(http.StatusNoContent)
+				}
+			})),
+			expectedErr: nil,
+		},
+		"bad request": {
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("bad request"),
+		},
+	}
+
+	for _, tc := range cases {
+		client, err := NewClientWithArgs(tc.server.URL, "", true, true, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = client.GetMigrationEnvironment(context.TODO(), tc.localSymID, tc.remoteSystemID)
+		if err != nil {
+			if tc.expectedErr.Error() != err.Error() {
+				t.Fatal(err)
+			}
+		}
+
+		tc.server.Close()
+	}
+}

--- a/migration_test.go
+++ b/migration_test.go
@@ -69,11 +69,21 @@ func TestModifyMigrationSession(t *testing.T) {
 			expectedErr: nil,
 		},
 		"bad request": {
+			localSymID:     "mock-local-sym-id",
+			storageGroupID: "mock-storage-group-id-2",
 			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 				resp.WriteHeader(http.StatusBadRequest)
 				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
 			})),
 			expectedErr: errors.New("bad request"),
+		},
+		"invalid array": {
+			localSymID: "invalid-array-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("the requested array (invalid-array-id) is ignored as it is not managed"),
 		},
 	}
 
@@ -82,13 +92,13 @@ func TestModifyMigrationSession(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		client.SetAllowedArrays([]string{"mock-local-sym-id"})
 		err = client.ModifyMigrationSession(context.TODO(), tc.localSymID, "mock-action", tc.storageGroupID)
 		if err != nil {
 			if tc.expectedErr.Error() != err.Error() {
 				t.Fatal(err)
 			}
 		}
-
 		tc.server.Close()
 	}
 }
@@ -130,11 +140,20 @@ func TestCreateMigrationEnvironment(t *testing.T) {
 			expectedErr: nil,
 		},
 		"bad request": {
+			localSymID: "mock-local-sym-id",
 			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 				resp.WriteHeader(http.StatusBadRequest)
 				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
 			})),
 			expectedErr: errors.New("bad request"),
+		},
+		"invalid array": {
+			localSymID: "invalid-array-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("the requested array (invalid-array-id) is ignored as it is not managed"),
 		},
 	}
 
@@ -143,13 +162,13 @@ func TestCreateMigrationEnvironment(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		client.SetAllowedArrays([]string{"mock-local-sym-id"})
 		_, err = client.CreateMigrationEnvironment(context.TODO(), tc.localSymID, tc.storageGroupID)
 		if err != nil {
 			if tc.expectedErr.Error() != err.Error() {
 				t.Fatal(err)
 			}
 		}
-
 		tc.server.Close()
 	}
 }
@@ -178,11 +197,20 @@ func TestDeleteMigrationEnvironment(t *testing.T) {
 			expectedErr: nil,
 		},
 		"bad request": {
+			localSymID: "mock-local-sym-id",
 			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 				resp.WriteHeader(http.StatusBadRequest)
 				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
 			})),
 			expectedErr: errors.New("bad request"),
+		},
+		"invalid array": {
+			localSymID: "invalid-array-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("the requested array (invalid-array-id) is ignored as it is not managed"),
 		},
 	}
 
@@ -191,13 +219,13 @@ func TestDeleteMigrationEnvironment(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		client.SetAllowedArrays([]string{"mock-local-sym-id"})
 		err = client.DeleteMigrationEnvironment(context.TODO(), tc.localSymID, tc.remoteSymID)
 		if err != nil {
 			if tc.expectedErr.Error() != err.Error() {
 				t.Fatal(err)
 			}
 		}
-
 		tc.server.Close()
 	}
 }
@@ -242,11 +270,20 @@ func TestCreateSGMigrationByID(t *testing.T) {
 			expectedErr: nil,
 		},
 		"bad request": {
+			localSymID: "mock-local-sym-id",
 			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 				resp.WriteHeader(http.StatusBadRequest)
 				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
 			})),
 			expectedErr: errors.New("bad request"),
+		},
+		"invalid array": {
+			localSymID: "invalid-array-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("the requested array (invalid-array-id) is ignored as it is not managed"),
 		},
 	}
 
@@ -255,13 +292,13 @@ func TestCreateSGMigrationByID(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		client.SetAllowedArrays([]string{"mock-local-sym-id"})
 		_, err = client.CreateSGMigration(context.TODO(), tc.localSymID, tc.remoteSymID, tc.storageGroupID)
 		if err != nil {
 			if tc.expectedErr.Error() != err.Error() {
 				t.Fatal(err)
 			}
 		}
-
 		tc.server.Close()
 	}
 }
@@ -318,11 +355,20 @@ func TestMigrateStorageGroup(t *testing.T) {
 			expectedErr: nil,
 		},
 		"bad request": {
+			localSymID: "mock-local-sym-id",
 			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 				resp.WriteHeader(http.StatusBadRequest)
 				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
 			})),
 			expectedErr: errors.New("bad request"),
+		},
+		"invalid array": {
+			localSymID: "invalid-array-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("the requested array (invalid-array-id) is ignored as it is not managed"),
 		},
 	}
 
@@ -331,13 +377,13 @@ func TestMigrateStorageGroup(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		client.SetAllowedArrays([]string{"mock-local-sym-id"})
 		_, err = client.MigrateStorageGroup(context.TODO(), tc.localSymID, tc.storageGroupID, tc.srpID, tc.serviceLevel, tc.thickVolumes)
 		if err != nil {
 			if tc.expectedErr.Error() != err.Error() {
 				t.Fatal(err)
 			}
 		}
-
 		tc.server.Close()
 	}
 }
@@ -381,11 +427,20 @@ func TestGetStorageGroupMigrationByID(t *testing.T) {
 			expectedErr: nil,
 		},
 		"bad request": {
+			localSymID: "mock-local-sym-id",
 			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 				resp.WriteHeader(http.StatusBadRequest)
 				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
 			})),
 			expectedErr: errors.New("bad request"),
+		},
+		"invalid array": {
+			localSymID: "invalid-array-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("the requested array (invalid-array-id) is ignored as it is not managed"),
 		},
 	}
 
@@ -394,13 +449,13 @@ func TestGetStorageGroupMigrationByID(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		client.SetAllowedArrays([]string{"mock-local-sym-id"})
 		_, err = client.GetStorageGroupMigrationByID(context.TODO(), tc.localSymID, tc.storageGroupID)
 		if err != nil {
 			if tc.expectedErr.Error() != err.Error() {
 				t.Fatal(err)
 			}
 		}
-
 		tc.server.Close()
 	}
 }
@@ -442,11 +497,20 @@ func TestGetStorageGroupMigration(t *testing.T) {
 			expectedErr: nil,
 		},
 		"bad request": {
+			localSymID: "mock-local-sym-id",
 			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 				resp.WriteHeader(http.StatusBadRequest)
 				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
 			})),
 			expectedErr: errors.New("bad request"),
+		},
+		"invalid array": {
+			localSymID: "invalid-array-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("the requested array (invalid-array-id) is ignored as it is not managed"),
 		},
 	}
 
@@ -455,13 +519,13 @@ func TestGetStorageGroupMigration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		client.SetAllowedArrays([]string{"mock-local-sym-id"})
 		_, err = client.GetStorageGroupMigration(context.TODO(), tc.localSymID)
 		if err != nil {
 			if tc.expectedErr.Error() != err.Error() {
 				t.Fatal(err)
 			}
 		}
-
 		tc.server.Close()
 	}
 }
@@ -506,11 +570,20 @@ func TestGetMigrationEnvironment(t *testing.T) {
 			expectedErr: nil,
 		},
 		"bad request": {
+			localSymID: "mock-local-sym-id",
 			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 				resp.WriteHeader(http.StatusBadRequest)
 				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
 			})),
 			expectedErr: errors.New("bad request"),
+		},
+		"invalid array": {
+			localSymID: "invalid-array-id",
+			server: httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+				resp.WriteHeader(http.StatusBadRequest)
+				resp.Write([]byte(`{"message":"bad request","httpStatusCode":400,"errorCode":0}`))
+			})),
+			expectedErr: errors.New("the requested array (invalid-array-id) is ignored as it is not managed"),
 		},
 	}
 
@@ -520,13 +593,13 @@ func TestGetMigrationEnvironment(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		client.SetAllowedArrays([]string{"mock-local-sym-id"})
 		_, err = client.GetMigrationEnvironment(context.TODO(), tc.localSymID, tc.remoteSystemID)
 		if err != nil {
 			if tc.expectedErr.Error() != err.Error() {
 				t.Fatal(err)
 			}
 		}
-
 		tc.server.Close()
 	}
 }

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -159,6 +159,7 @@ type inducedErrors struct {
 	GetPortError                           bool
 	GetSpecificPortError                   bool
 	GetPortISCSITargetError                bool
+	GetPortNVMeTCPTargetError              bool
 	GetPortGigEError                       bool
 	GetDirectorError                       bool
 	GetInitiatorError                      bool
@@ -365,6 +366,7 @@ func Reset() {
 	InducedErrors.GetPortError = false
 	InducedErrors.GetSpecificPortError = false
 	InducedErrors.GetPortISCSITargetError = false
+	InducedErrors.GetPortNVMeTCPTargetError = false
 	InducedErrors.GetPortGigEError = false
 	InducedErrors.GetDirectorError = false
 	InducedErrors.GetInitiatorError = false
@@ -686,6 +688,7 @@ func getRouter() http.Handler {
 	router.HandleFunc(PREFIX+"/system/version", HandleVersion)
 	router.HandleFunc(PREFIX+"/version", HandleVersion)
 	router.HandleFunc(PREFIXNOVERSION+"/version", HandleVersion)
+	router.HandleFunc(PREFIX+"/system/symmetrix/{id}/refresh", HandleSymmetrix)
 	router.HandleFunc("/", HandleNotFound)
 
 	// StorageGroup Snapshots
@@ -3292,6 +3295,10 @@ func handlePort(w http.ResponseWriter, r *http.Request) {
 					writeError(w, "Error retrieving GigE ports: induced error", http.StatusRequestTimeout)
 					return
 				}
+				if queryType[0] == "OSHostAndRDF" { // The first ?type=<value>
+					writeError(w, "Error retrieving OSHostAndRDF ports: induced error", http.StatusRequestTimeout)
+					return
+				}
 			}
 		}
 		if InducedErrors.GetPortISCSITargetError {
@@ -3299,6 +3306,15 @@ func handlePort(w http.ResponseWriter, r *http.Request) {
 			if ok {
 				if queryType[0] == "true" { // The first ?iscsi_target=<value>
 					writeError(w, "Error retrieving ISCSI targets: induced error", http.StatusRequestTimeout)
+					return
+				}
+			}
+		}
+		if InducedErrors.GetPortNVMeTCPTargetError {
+			queryType, ok := queryString["nvmetcp_endpoint"]
+			if ok {
+				if queryType[0] == "true" { // The first ?nvmetcp_endpoint=<value>
+					writeError(w, "Error retrieving NVMeTCP targets: induced error", http.StatusRequestTimeout)
 					return
 				}
 			}

--- a/sloprovisioning.go
+++ b/sloprovisioning.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/sloprovisioning.go
+++ b/sloprovisioning.go
@@ -50,7 +50,7 @@ const (
 
 // TimeSpent - Calculates and prints time spent for a caller function
 func (c *Client) TimeSpent(functionName string, startTime time.Time) {
-	if logResponseTimes {
+	if c.opts.logResponseTimes {
 		if functionName == "" {
 			pc, _, _, ok := runtime.Caller(1)
 			details := runtime.FuncForPC(pc)

--- a/system.go
+++ b/system.go
@@ -381,7 +381,7 @@ func (c *Client) GetNVMeTCPTargets(ctx context.Context, symID string) ([]NVMeTCP
 	}
 
 	for _, d := range directors.DirectorIDs {
-		// Check if director is ISCSI
+		// Check if director is NVMETCP
 		// To do this, check if any ports have ports with GigE enabled
 		ports, err := c.GetPortList(ctx, symID, d, "type=OSHostAndRDF")
 		if err != nil {
@@ -391,8 +391,8 @@ func (c *Client) GetNVMeTCPTargets(ctx context.Context, symID string) ([]NVMeTCP
 			continue
 		}
 		if len(ports.SymmetrixPortKey) > 0 {
-			// This is a director with ISCSI port(s)
-			// Query for iscsi_targets
+			// This is a director with NVMeTCP port(s)
+			// Query for nvmetcp_endpoints
 			virtualPorts, err := c.GetPortList(ctx, symID, d, "nvmetcp_endpoint=true")
 			if err != nil {
 				return []NVMeTCPTarget{}, err

--- a/system.go
+++ b/system.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/types/v100/types.go
+++ b/types/v100/types.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/types/v100/types.go
+++ b/types/v100/types.go
@@ -103,15 +103,15 @@ type StoragePool struct {
 
 // FbaCap FBA storage pool capacity
 type FbaCap struct {
-	Provisioned *provisioned `json:"provisioned"`
+	Provisioned *Provisioned `json:"provisioned"`
 }
 
 // CkdCap CKD storage pool capacity
 type CkdCap struct {
-	Provisioned *provisioned `json:"provisioned"`
+	Provisioned *Provisioned `json:"provisioned"`
 }
 
-type provisioned struct {
+type Provisioned struct {
 	UsableUsedInTB float64 `json:"used_tb"`
 	UsableTotInTB  float64 `json:"effective_capacity_tb"`
 	//	EffectiveUsedCapacityPercent float64 `json:"provisioned_percent"`

--- a/types/v100/types_test.go
+++ b/types/v100/types_test.go
@@ -1,0 +1,87 @@
+package v100
+
+import "testing"
+
+func TestGetJobResource(t *testing.T) {
+	tests := []struct {
+		name                 string
+		job                  Job
+		expectedSymmetrixID  string
+		expectedResourceType string
+		expectedResourceID   string
+	}{
+		{
+			name: "valid resource link",
+			job: Job{
+				ResourceLink: "provisioning/system/SYMMETRIX-1234/volume/1234",
+			},
+			expectedSymmetrixID:  "SYMMETRIX-1234",
+			expectedResourceType: "volume",
+			expectedResourceID:   "1234",
+		},
+		{
+			name: "Empty resource link",
+			job: Job{
+				ResourceLink: "",
+			},
+			expectedSymmetrixID:  "",
+			expectedResourceType: "",
+			expectedResourceID:   "",
+		},
+		{
+			name: "invalid resource link",
+			job: Job{
+				ResourceLink: "system/SYMMETRIX-1234",
+			},
+			expectedSymmetrixID:  "",
+			expectedResourceType: "",
+			expectedResourceID:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			symID, resourceType, id := tt.job.GetJobResource()
+
+			if symID != tt.expectedSymmetrixID {
+				t.Errorf("expected %s, got %s", tt.expectedSymmetrixID, symID)
+			}
+
+			if resourceType != tt.expectedResourceType {
+				t.Errorf("expected %s, got %s", tt.expectedResourceType, resourceType)
+			}
+
+			if id != tt.expectedResourceID {
+				t.Errorf("expected %s, got %s", tt.expectedResourceID, id)
+			}
+		})
+	}
+}
+
+func TestError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *Error
+	}{
+		{
+			name: "valid error",
+			err: &Error{
+				Message: "test-error",
+			},
+		},
+		{
+			name: "empty error",
+			err: &Error{
+				Message: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err.Error() != tt.err.Message {
+				t.Errorf("expected %s, got %s", tt.err.Message, tt.err.Error())
+			}
+		})
+	}
+}

--- a/types/v100/types_test.go
+++ b/types/v100/types_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v100
 
 import "testing"

--- a/unit_steps_test.go
+++ b/unit_steps_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/unit_steps_test.go
+++ b/unit_steps_test.go
@@ -1075,7 +1075,7 @@ func (c *unitContext) iCallRenameMaskingViewWith(newName string) error {
 }
 
 func (c *unitContext) iHaveAPortGroup() error {
-	mock.AddPortGroup(testPortGroup, "ISCSI", []string{"SE-1E:000"})
+	mock.AddPortGroupWithPortID(testPortGroup, "ISCSI", []string{"SE-1E:000"})
 	return nil
 }
 

--- a/unit_steps_test.go
+++ b/unit_steps_test.go
@@ -74,6 +74,7 @@ type unitContext struct {
 
 	symIDList                  *types.SymmetrixIDList
 	sym                        *types.Symmetrix
+	directorIDList             *types.DirectorIDList
 	vol                        *types.Volume
 	volList                    []string
 	storageGroup               *types.StorageGroup
@@ -95,6 +96,7 @@ type unitContext struct {
 	uMaskingView               *uMV
 	addressList                []string
 	targetList                 []ISCSITarget
+	nvmeTCPTargetList          []NVMeTCPTarget
 	storagePool                *types.StoragePool
 	volIDList                  []string
 	hostID                     string
@@ -350,6 +352,8 @@ func (c *unitContext) iInduceError(errorType string) error {
 		mock.InducedErrors.GetPortGigEError = true
 	case "GetPortISCSITargetError":
 		mock.InducedErrors.GetPortISCSITargetError = true
+	case "GetPortNVMeTCPTargetError":
+		mock.InducedErrors.GetPortNVMeTCPTargetError = true
 	case "GetDirectorError":
 		mock.InducedErrors.GetDirectorError = true
 	case "GetStoragePoolError":
@@ -638,6 +642,11 @@ func (c *unitContext) iCallGetVolumeIDListWithParams() error {
 		"cap_tb": "=1.0",
 	}
 	c.volList, c.err = c.client.GetVolumeIDListWithParams(context.TODO(), symID, param)
+	return nil
+}
+
+func (c *unitContext) iCallGetVolumeIDListInStorageGroup(sgID string) error {
+	c.volList, c.err = c.client.GetVolumeIDListInStorageGroup(context.TODO(), symID, sgID)
 	return nil
 }
 
@@ -1882,6 +1891,16 @@ func (c *unitContext) iCallGetISCSITargets() error {
 	return nil
 }
 
+func (c *unitContext) iCallGetNVMeTCPTargets() error {
+	c.nvmeTCPTargetList, c.err = c.client.GetNVMeTCPTargets(context.TODO(), symID)
+	return nil
+}
+
+func (c *unitContext) iCallRefreshSymmetrix(id string) error {
+	c.err = c.client.RefreshSymmetrix(context.TODO(), id)
+	return nil
+}
+
 func (c *unitContext) iRecieveTargets(count int) error {
 	if len(c.targetList) != count {
 		return fmt.Errorf("expected to get %d targets but recieved %d", count, len(c.targetList))
@@ -2611,6 +2630,11 @@ func (c *unitContext) iGetAValidFileInterfaceObjectIfNoError() error {
 	return nil
 }
 
+func (c *unitContext) iCallGetDirectorIDList() error {
+	c.directorIDList, c.err = c.client.GetDirectorIDList(context.TODO(), symID)
+	return nil
+}
+
 func UnitTestContext(s *godog.ScenarioContext) {
 	c := &unitContext{}
 	s.Step(`^I induce error "([^"]*)"$`, c.iInduceError)
@@ -2642,6 +2666,7 @@ func UnitTestContext(s *godog.ScenarioContext) {
 	s.Step(`^I call GetJobByID$`, c.iCallGetJobByID)
 	s.Step(`^I get a valid Job with state "([^"]*)" if no error$`, c.iGetAValidJobWithStateIfNoError)
 	s.Step(`^I call WaitOnJobCompletion$`, c.iCallWaitOnJobCompletion)
+	s.Step(`^I call RefreshSymmetrix "([^"]*)"$`, c.iCallRefreshSymmetrix)
 	// Volumes
 	s.Step(`^I call CreateVolumeInStorageGroup with name "([^"]*)" and size (\d+)$`, c.iCallCreateVolumeInStorageGroupWithNameAndSize)
 	s.Step(`^I call CreateVolumeInStorageGroup with name "([^"]*)" and size (\d+) and unit "([^"]*)"$`, c.iCallCreateVolumeInStorageGroupWithNameAndSizeAndUnit)
@@ -2722,6 +2747,7 @@ func UnitTestContext(s *godog.ScenarioContext) {
 	s.Step(`^then the Volumes are part of StorageGroup if no error$`, c.thenTheVolumesArePartOfStorageGroupIfNoError)
 	s.Step(`^I call UpdateHost$`, c.iCallUpdateHost)
 	s.Step(`^I call UpdateHostFlags$`, c.iCallUpdateHostFlags)
+	s.Step(`^I call GetVolumeIDListInStorageGroup "([^"]*)"$`, c.iCallGetVolumeIDListInStorageGroup)
 	// GetListOftargetAddresses
 	s.Step(`^I call GetListOfTargetAddresses$`, c.iCallGetListOfTargetAddresses)
 	s.Step(`^I recieve (\d+) IP addresses$`, c.iRecieveIPAddresses)
@@ -2770,6 +2796,7 @@ func UnitTestContext(s *godog.ScenarioContext) {
 	s.Step(`^I call GetPrivVolumeByID with "([^"]*)"$`, c.iCallGetPrivVolumeByIDWith)
 	s.Step(`^I should get a private volume information if no error$`, c.iShouldGetAPrivateVolumeInformationIfNoError)
 	s.Step(`^I call GetISCSITargets$`, c.iCallGetISCSITargets)
+	s.Step(`^I call GetNVMeTCPTargets$`, c.iCallGetNVMeTCPTargets)
 	s.Step(`^I recieve (\d+) targets$`, c.iRecieveTargets)
 	s.Step(`^there should be no errors$`, c.thereShouldBeNoErrors)
 	s.Step(`^I call UpdateHostName "([^"]*)"$`, c.iCallUpdateHostName)

--- a/unittest/pmax.feature
+++ b/unittest/pmax.feature
@@ -1054,6 +1054,17 @@ Scenario Outline: Test GetHostList
     | "000197900046"  | "000197900046"        | "none"                           |
     | "000197900046"  | "000197802104"        | "ignored as it is not managed"   |
 
+  Scenario Outline: Refresh Symmetrix system
+    Given a valid connection
+    And I have an allowed list of <allowedarrays>
+    When I call RefreshSymmetrix <array>
+    Then the error message contains <errormsg>
+    Examples:
+    | allowedarrays   | array               | errormsg                            |
+    | "000197900046"  |  "000197900046"     | "none"                              | 
+    | "000197900046"  |  "000011112222"     |"is ignored as it is not managed"    |
+
+
   Scenario Outline: Get ISCSI targets
     Given a valid connection
     And I have an allowed list of <arrays>
@@ -1069,6 +1080,23 @@ Scenario Outline: Test GetHostList
     | "000197900046"   | "GetPortISCSITargetError" | "Error retrieving ISCSI targets" | 0     |
     | "000197900046"   | "GetSpecificPortError"    | "none"                           | 0     |
     | "000197900046"   | "none"                    | "none"                           | 8     |
+
+  Scenario Outline: Get NVMeTCP targets
+    Given a valid connection
+    And I have an allowed list of <arrays>
+    And I induce error <induced>
+    When I call GetNVMeTCPTargets
+    Then the error message contains <errormsg>
+    And I recieve <count> targets
+    Examples:
+    | arrays           | induced                     | errormsg                           | count |
+    | "000197900046"   | "none"                      | "none"                             | 0     |
+    | "000000000000"   | "none"                      | "ignored as it is not managed"     | 0     |
+    | "000197900046"   | "GetDirectorError"          | "Error retrieving Director"        | 0     |
+    | "000197900046"   | "GetPortGigEError"          | "none"                             | 0     |
+    | "000197900046"   | "GetSpecificPortError"      | "none"                             | 0     |
+    | "000197900046"   | "GetPortNVMeTCPTargetError" | "Error retrieving NVMeTCP targets" | 0     |
+   
 
   Scenario Outline: Test UpdateHostName
       Given a valid connection
@@ -1206,3 +1234,18 @@ Scenario Outline: Test GetHostList
     | nvols      | vols  | induced                    | errormsg                      | arrays    |
     | 7          | 7     | "none"                     | "none"                        | ""        |
     | 5          | 5     | "none"                     | "ignored as it is not managed"| "ignore"  |
+
+  Scenario Outline: Test cases for GetStorageGroupVolumeIDList
+    Given a valid connection
+    And I have an allowed list of <arrays>
+    And I have a StorageGroup <sgname>
+    And I have <nvols> volumes
+    And I induce error <induced>
+    When I call GetVolumeIDListInStorageGroup <sgname>
+    Then the error message contains <errormsg>
+    And I get a valid VolumeIDList with <vols> if no error
+
+    Examples:
+    | nvols      | vols  | induced  | errormsg                      | arrays          | sgname      | 
+    | 7          | 7     | "none"   | "none"                        | "000197900046"  | "TestSG"    | 
+    | 5          | 5     | "none"   | "storageGroupID is empty"     | "000197900046"  | ""          |


### PR DESCRIPTION
# Description

Refactoring the mock server to address data races around accessing the global struct of "Induced errors".

Unit tests executed by csi-powermax have a dependency on the mock PowerMax server in `mock.go`. This server handles requests made by csi-powermax code when executing its unit tests. In order to induce errors, there is a global set of boolean vars within the mock server that is set by csi-powermax unit test code, and also read by the running server, leading to data races.

  To resolve this, functions that read or otherwise modify the global vars have been unexported, and associated exported functions with the same name and func signature will call these unexported funcs, making sure to acquire the lock first. If necessary, unexported funcs should only call other unexported funcs to avoid deadlock.

Increasing unit test coverage.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1747 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained at least 90% code coverage?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
