### PR TITLE
CSI-PowerMax driver incorrectly labelling nodes for nfs protocol

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -443,4 +443,10 @@ type Pmax interface {
 
 	// RefreshSymmetrix refreshes cache on the symID
 	RefreshSymmetrix(ctx context.Context, symID string) error
+
+	// GetNFSServerList get NFS Server list on a symID
+	GetNFSServerList(ctx context.Context, symID string) (*types.NFSServerIterator, error)
+
+	// GetNFSServerByID fetch specific NFS server on symID
+	GetNFSServerByID(ctx context.Context, symID, nfsID string) (*types.NFSServer, error)
 }

--- a/types/v100/file.go
+++ b/types/v100/file.go
@@ -289,3 +289,20 @@ type FileInterface struct {
 	IsDisabled bool   `json:"is_disabled"`
 	Override   bool   `json:"override"`
 }
+
+// NFSServerList holds nfs server metadata items
+type NFSServerList struct {
+	ID string `json:"id"`
+}
+
+// NFSServerIterator holds the iterator of resultant NFS server list
+type NFSServerIterator struct {
+	Entries []NFSServerList `json:"entries"`
+}
+
+// NFSServer holds nfs server details
+type NFSServer struct {
+	ID           string `json:"id"`
+	NFSV3Enabled bool   `json:"nfsv3_enabled"`
+	NFSV4Enabled bool   `json:"nfsv4_enabled"`
+}

--- a/unittest/file.feature
+++ b/unittest/file.feature
@@ -283,3 +283,37 @@ Feature: PMAX file test
       | "id1"         | "httpStatus500"          | "Internal Error"              | ""        |
       | "id1"         | "InvalidJSON"            | "invalid character"           | ""        |
       | "id1"         | "none"                   | "ignored as it is not managed"| "ignored" |
+
+  @v2.4.0
+  Scenario Outline: TestCases for GetNFSServerList
+    Given a valid connection
+    And I induce error <induced>
+    When I call GetNFSServerList
+    Then the error message contains <errormsg>
+    And I get a valid NFS Server ID List if no error
+
+    Examples:
+      | induced                    | errormsg               |
+      | "none"                     | "none"                 |
+      | "GetNFSServerListError"    | "induced error"        |
+      | "InvalidResponse"          | "EOF"                  |
+
+  @v2.4.0
+  Scenario Outline: Test cases for GetNFSServerByID
+    Given a valid connection
+    And I have an allowed list of <arrays>
+    And I induce error <induced>
+    When I call GetNFSServerByID <id>
+    Then the error message contains <errormsg>
+    And I get a valid nfsServer Object if no error
+
+    Examples:
+      | id            | induced                  | errormsg                      | arrays    |
+      | "id1"         | "none"                   | "none"                        | ""        |
+      | "id3"         | "none"                   | "cannot be found"             | ""        |
+      | "id1"         | "GetNFSServerError"      | "induced error"               | ""        |
+      | "id1"         | "InvalidResponse"        | "EOF"                         | ""        |
+      | "id1"         | "httpStatus500"          | "Internal Error"              | ""        |
+      | "id1"         | "InvalidJSON"            | "invalid character"           | ""        |
+      | "id1"         | "none"                   | "ignored as it is not managed"| "ignored" |
+


### PR DESCRIPTION
# Description
Added methods to provide the details of the NFS servers. These are consumed by the csi-powermax driver, NodeGetInfo() to check if the array in question has the NFS configured in it, and accordingly set the topology keys/labels for the node objects.

Corresponding csi-powermax PR: https://github.com/dell/csi-powermax/pull/550

# GitHub Issues

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1808|

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Have you maintained at least 90% code coverage?

# How Has This Been Tested?
New unit tests are added and all the existing unit tests are executed with any failures.
Deployed the csi-powermax driver with these changes and driver able to query the NFS details using the new methods.